### PR TITLE
Friendlier env var naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-API_TOKEN="superlongkey"
+MAILERSEND_API_TOKEN="superlongkey"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You will have to initalize it in your Ruby file with `require "mailersend-ruby"`
 
 # Usage
 
-This SDK requires that you either have `.env` file with `API_TOKEN` env variable or that your variable is enabled system wide (useful for Docker/Kubernetes). The example of how `API_TOKEN` should look like is in `.env.example`.
+This SDK requires that you either have `.env` file with `MAILERSEND_API_TOKEN` env variable or that your variable is enabled system wide (useful for Docker/Kubernetes). The example of how `MAILERSEND_API_TOKEN` should look like is in `.env.example`.
 
 ## Email
 

--- a/lib/mailersend/client.rb
+++ b/lib/mailersend/client.rb
@@ -6,7 +6,7 @@ require 'dotenv/load'
 API_URL = 'https://api.mailersend.com/v1'
 API_BASE_HOST = 'api.mailersend.com'
 
-Dotenv.require_keys('API_TOKEN')
+Dotenv.require_keys('MAILERSEND_API_TOKEN')
 
 # mailersend-ruby is a gem that integrates all endpoints from MailerSend API
 module Mailersend
@@ -14,7 +14,7 @@ module Mailersend
 
   # Inits the client.
   class Client
-    def initialize(api_token = ENV['API_TOKEN'])
+    def initialize(api_token = ENV['MAILERSEND_API_TOKEN'])
       @api_token = api_token
     end
 

--- a/lib/mailersend/email/email.rb
+++ b/lib/mailersend/email/email.rb
@@ -112,6 +112,8 @@ module Mailersend
       response = client.http.post("#{API_URL}/email", json: message.delete_if { |_, value| value.to_s.strip == '' || value == [] || value == {} })
       puts response
       puts response.status.code
+      # Return the actual response here for users to perform in-app error handling
+      return response
     end
   end
 end


### PR DESCRIPTION
I am suggesting that Mailersend modify the naming of the environment variable that is required.

Reasoning:
`API_TOKEN` is extraordinarily generic, and it's extremely likely that clients will be using multiple APIs in their products. Namespacing your environment variables with `MAILERSEND_` communicates exactly which service this environment variable is for; without it, I am left wondering where `API_TOKEN` came from.