### PR TITLE
Use Rails.configuration instead of ENV and dotenv for API Keys

### DIFF
--- a/lib/mailersend/client.rb
+++ b/lib/mailersend/client.rb
@@ -11,7 +11,7 @@ module Mailersend
 
   # Inits the client.
   class Client
-    def initialize(api_token:)
+    def initialize(api_token: Rails.configuration.mailersend_api_token)
       @api_token = api_token
     end
 

--- a/lib/mailersend/client.rb
+++ b/lib/mailersend/client.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
 require 'http'
-require 'dotenv/load'
 
 API_URL = 'https://api.mailersend.com/v1'
 API_BASE_HOST = 'api.mailersend.com'
-
-Dotenv.require_keys('MAILERSEND_API_TOKEN')
 
 # mailersend-ruby is a gem that integrates all endpoints from MailerSend API
 module Mailersend
@@ -14,7 +11,7 @@ module Mailersend
 
   # Inits the client.
   class Client
-    def initialize(api_token = ENV['MAILERSEND_API_TOKEN'])
+    def initialize(api_token:)
       @api_token = api_token
     end
 

--- a/mailersend-ruby.gemspec
+++ b/mailersend-ruby.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.4.1'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 1.7'
-  spec.add_dependency 'dotenv', '~> 2.7'
   spec.add_dependency 'http', '~> 5.0'
   spec.add_dependency 'json', '~> 2.5'
   spec.add_dependency 'uri', '~> 0.12.0'


### PR DESCRIPTION
I have modified the Client class to allow for passing the API token as an argument to the constructor. The default value for the API token is now ```Rails.configuration.mailersend_api_token``` so that the API token can be stored in the application configuration. The dotenv dependency has also been removed.

You can have seperate keys for each enviroment, for example:
``` config.mailersend_api_token = Rails.application.credentials.mailersend&.dig(:api_tokens, :development) ```
in ```development.rb``` and 
``` config.mailersend_api_token = Rails.application.credentials.mailersend&.dig(:api_tokens, :production) ```
in ``` production.rb ```