### PR TITLE
Added supports for base64 attachment

### DIFF
--- a/lib/mailersend/email/email.rb
+++ b/lib/mailersend/email/email.rb
@@ -87,10 +87,20 @@ module Mailersend
     end
 
     def add_attachment(content:, filename:, disposition:)
-      data = File.read(content.to_s)
-      encoded = Base64.strict_encode64(data)
+      # content: Can be one of the following:
+      # file_path(String) i.e. 'app/Sample-jpg-image-50kb.jpeg'
+      # Base64 encoded string (String)
+      # Supported types are: https://developers.mailersend.com/api/v1/email.html#supported-file-types
+
+      content_string = content.to_s
+      if File.readable?(content_string)
+        data = File.read(content_string)
+        base64_encoded = Base64.strict_encode64(data)
+      else
+        base64_encoded = content_string
+      end
       @attachments << {
-        'content' => encoded,
+        'content' => base64_encoded,
         'filename' => filename,
         'disposition' => disposition
       }

--- a/lib/mailersend/email/email.rb
+++ b/lib/mailersend/email/email.rb
@@ -99,11 +99,7 @@ module Mailersend
       else
         base64_encoded = content_string
       end
-      @attachments << {
-        'content' => base64_encoded,
-        'filename' => filename,
-        'disposition' => disposition
-      }
+      @attachments << { 'content' => base64_encoded, 'filename' => filename, 'disposition' => disposition }
     end
 
     def add_send_at(send_at)


### PR DESCRIPTION
It used to supports only File path for attachment in 'content'.

Now 'content' argument will supports one of the following: File path (as it was before) and Base64 encoded string