### PR TITLE
Remove uninitialized variable

### DIFF
--- a/lib/mailersend/sender_identity/sender_identity.rb
+++ b/lib/mailersend/sender_identity/sender_identity.rb
@@ -25,7 +25,6 @@ module Mailersend
       }
       client.http.get(URI::HTTPS.build(host: API_BASE_HOST, path: '/v1/identities',
                                        query: URI.encode_www_form(hash.compact)))
-      puts response
     end
 
     def single(identity_id:)


### PR DESCRIPTION
Reference to: https://github.com/mailersend/mailersend-ruby/issues/62

- This PR removes `puts response` from the `SenderIdentity#list` method since `response` is not previously initialized.