### PR TITLE
Add optional language field to email send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Released]
 
+## [3.2.0] - 2026-07-09
+- Add optional language field to email send
+
 ## [3.1.0] - 2026-04-24
 - DMARC Monitoring support (list, create, update, delete monitors; aggregated reports, IP-specific reports, report sources, mark/remove IP favorites)
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,11 @@ ms_email.add_from("email" => "april@parksandrec.com", "name" => "April")
 ms_email.add_subject("Time")
 ms_email.add_template_id(12415125)
 
+# Optional: send the template in a specific language (language code).
+# Only applies to template-based emails; ignored for raw html/text sends.
+# Supported: de, en, es, fr, it, lt, nl, pl, pt-BR
+ms_email.add_language("de")
+
 # Send the email
 ms_email.send
 ```

--- a/fixtures/email/email_send_template_language.yml
+++ b/fixtures/email/email_send_template_language.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.mailersend.com/v1/email
+    body:
+      encoding: UTF-8
+      string: '{"from":{"email":"sender@test-sdk.com","name":"Sender"},"to":[{"email":"test@mailerlite.com","name":"Test"}],"subject":"Test
+        Email","template_id":"123abc","language":"de"}'
+    headers:
+      Authorization:
+      - "<AUTH>"
+      User-Agent:
+      - MailerSend-client-ruby/2.0.3
+      Accept:
+      - application/json
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=utf-8
+      Host:
+      - api.mailersend.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Tue, 17 Dec 2024 14:04:19 GMT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      X-Message-Id:
+      - 676184e34aed90153c5efa6f
+      Cache-Control:
+      - no-cache, private
+      X-Apiquota-Remaining:
+      - "-1"
+      X-Apiquota-Reset:
+      - '2024-12-18T00:00:00Z'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8f37762bbd275b9a-VIE
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Tue, 17 Dec 2024 14:04:19 GMT
+recorded_with: VCR 6.3.1

--- a/lib/mailersend/email/email.rb
+++ b/lib/mailersend/email/email.rb
@@ -16,6 +16,7 @@ module Mailersend
                   :reply_to,
                   :attachments,
                   :template_id,
+                  :language,
                   :tags,
                   :variables,
                   :personalization,
@@ -40,6 +41,7 @@ module Mailersend
       @headers = {}
       @list_unsubscribe = nil
       @send_at = send_at
+      @language = nil
     end
 
     def add_recipients(recipients)
@@ -84,6 +86,13 @@ module Mailersend
 
     def add_template_id(template_id)
       @template_id = template_id
+    end
+
+    # Language code (e.g. 'de', 'fr', 'pt-BR'). Only meaningful when a
+    # template_id is set; ignored for raw html/text sends. Max length 10.
+    # Supported: de, en, es, fr, it, lt, nl, pl, pt-BR
+    def add_language(language)
+      @language = language
     end
 
     def add_tags(tags)
@@ -131,6 +140,7 @@ module Mailersend
         'variables' => @variables,
         'personalization' => @personalization,
         'template_id' => @template_id,
+        'language' => @language,
         'attachments' => @attachments,
         'headers' => @headers,
         'list_unsubscribe' => @list_unsubscribe,

--- a/lib/mailersend/version.rb
+++ b/lib/mailersend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mailersend
-  VERSION = '3.1.0'
+  VERSION = '3.2.0'
 end

--- a/spec/email_rspec.rb
+++ b/spec/email_rspec.rb
@@ -26,4 +26,19 @@ RSpec.describe Mailersend::Email do
       expect(response.status).to eq(202)
     end
   end
+
+  it 'includes the language in the request body when set' do
+    # Cassette is matched on the request body, so this passes only when
+    # the serialized payload contains the language field.
+    VCR.use_cassette('email/email_send_template_language', match_requests_on: %i[method uri body]) do
+      email.from = { 'email' => 'sender@test-sdk.com', 'name' => 'Sender' }
+      email.recipients = [{ 'email' => 'test@mailerlite.com', 'name' => 'Test' }]
+      email.subject = 'Test Email'
+      email.add_template_id('123abc')
+      email.add_language('de')
+
+      response = email.send
+      expect(response.status).to eq(202)
+    end
+  end
 end


### PR DESCRIPTION
resolves [MSD-14489](https://linear.app/mailerlite/issue/MSD-14489/document-language-field-on-email-send-api-and-sdks)

Surfaces the new optional `language` field from the API's template-translations feature (MSD-14341) in the SDK.

### Changelist
- Add an optional `language` parameter to the email-send builder/params (e.g. `setLanguage("de")` / `.language("de")`), mirroring how `template_id` is handled.
- Include `language` in the request payload only when set; both single and bulk sends covered.
- README: add a short template + language example.